### PR TITLE
Introのindex訳の改善

### DIFF
--- a/TranslationTableEmbedded.md
+++ b/TranslationTableEmbedded.md
@@ -20,3 +20,4 @@
 | flash                          | 書き込む
 | halt                           | 停止
 | terminal                       | 端末
+| peripheral                     | ペリフェラル

--- a/src/intro/index.md
+++ b/src/intro/index.md
@@ -108,7 +108,7 @@
 | Rust、組込み | [Embedded Rust Bookshelf](https://docs.rust-embedded.org) | Rust組込みワーキンググループによるいくらかのリソースがあります。 |
 | Rust、組込み | [Embedonomicon](https://docs.rust-embedded.org/embedonomicon/) | Rustで組込みプログラミングを行うときのより深い詳細が記載されています。 |
 | Rust、組込み | [embedded FAQ](https://docs.rust-embedded.org/faq.html) | 組込みでRustを使う際のよくある質問と回答です。 |
-| 割り込み | [Interrupt](https://en.wikipedia.org/wiki/Interrupt) | - |
+| 割込み | [Interrupt](https://en.wikipedia.org/wiki/Interrupt) | - |
 | メモリマップドI/O／ペリフェラル | [Memory-mapped I/O](https://en.wikipedia.org/wiki/Memory-mapped_I/O) | - |
 | SPI, UART, RS232, USB, I2C, TTL | [Stack Exchange about SPI, UART, and other interfaces](https://electronics.stackexchange.com/questions/37814/usart-uart-rs232-usb-spi-i2c-ttl-etc-what-are-all-of-these-and-how-do-th) | - |
 

--- a/src/intro/index.md
+++ b/src/intro/index.md
@@ -5,7 +5,7 @@
 <!-- Welcome to The Embedded Rust Book: An introductory book about using the Rust -->
 <!-- Programming Language on "Bare Metal" embedded systems, such as Microcontrollers. -->
 
-*The Embedded Rust Book*へようこそ。Rustをマイクロコントローラのような、`ベアメタル`の組込みシステムで使うための入門書です。
+*The Embedded Rust Book*へようこそ。Rustをマイクロコントローラのような、「ベアメタル」の組込みシステムで使うための入門書です。
 
 <!-- ## Who Embedded Rust is For -->
 <!-- Embedded Rust is for everyone who wants to do embedded programming backed by the higher-level concepts and safety guarantees the Rust language provides. -->
@@ -56,7 +56,7 @@
 <!-- you want to catch up on. -->
 
 ## この本は誰のためのもの
-本書は、組込み開発か、Rustかのバックグラウンドを持つ人々に向けたものです。しかし、組込みRustに興味がある人なら、誰でも、この本から何かを得られると思います。本書による学習効果を高めるために、事前知識が不足している読者は、`仮定と前提条件`のセクションを読み、不足している知識を補うことをお勧めします。不足知識を補うリソースを見つけるために、`その他のリソース`セクションをチェックすることができます。
+本書は、組込み開発か、Rustかのバックグラウンドを持つ人々に向けたものです。しかし、組込みRustに興味がある人なら、誰でも、この本から何かを得られると思います。本書による学習効果を高めるために、事前知識が不足している読者は、「仮定と前提条件」のセクションを読み、不足している知識を補うことをお勧めします。不足知識を補うリソースを見つけるために、「その他のリソース」セクションをチェックすることができます。
 
 <!-- ### Assumptions and Prerequisites -->
 
@@ -78,10 +78,10 @@
 <!--     * Interrupts -->
 <!--     * Common interfaces such as I2C, SPI, Serial, etc. -->
 
-* C, C++, Adaといった言語で組込みシステムを開発、デバッグすることを楽しんでおり、次の概念になじみがあることを想定します。
+* C, C++, Adaといった言語で組込みシステムを開発、デバッグすることに慣れており、次の概念になじみがあることを想定します。
     * クロスコンパイル
-    * メモリマップド周辺機器
-    * 割り込み
+    * メモリマップ方式のペリフェラル
+    * 割込み
     * I2C、SPI、シリアルといった一般的なインタフェース
 
 <!-- ### Other Resources -->
@@ -105,11 +105,11 @@
 | トピック      | リソース   | 説明 |
 |--------------|----------|-------------|
 | Rust         | [Rust Book 2018 Edition](https://doc.rust-lang.org/book/2018-edition/index.html) | もしRustに親しんでいない場合、この本を読むことを強くお勧めします。 |
-| Rust, Embedded | [Embedded Rust Bookshelf](https://docs.rust-embedded.org) | Rust組込みワーキンググループによるいくらかのリソースがあります。 |
-| Rust, Embedded | [Embedonomicon](https://docs.rust-embedded.org/embedonomicon/) | Rustで組込みプログラミングを行うとき固有の実用的な詳細が記載されています。 |
-| Rust, Embedded | [embedded FAQ](https://docs.rust-embedded.org/faq.html) | 組込みでRustを使う際のよくある質問と回答です。 |
-| Interrupts | [Interrupt](https://en.wikipedia.org/wiki/Interrupt) | - |
-| Memory-mapped IO/Peripherals | [Memory-mapped I/O](https://en.wikipedia.org/wiki/Memory-mapped_I/O) | - |
+| Rust、組込み | [Embedded Rust Bookshelf](https://docs.rust-embedded.org) | Rust組込みワーキンググループによるいくらかのリソースがあります。 |
+| Rust、組込み | [Embedonomicon](https://docs.rust-embedded.org/embedonomicon/) | Rustで組込みプログラミングを行うときのより深い詳細が記載されています。 |
+| Rust、組込み | [embedded FAQ](https://docs.rust-embedded.org/faq.html) | 組込みでRustを使う際のよくある質問と回答です。 |
+| 割り込み | [Interrupt](https://en.wikipedia.org/wiki/Interrupt) | - |
+| メモリマップドI/O／ペリフェラル | [Memory-mapped I/O](https://en.wikipedia.org/wiki/Memory-mapped_I/O) | - |
 | SPI, UART, RS232, USB, I2C, TTL | [Stack Exchange about SPI, UART, and other interfaces](https://electronics.stackexchange.com/questions/37814/usart-uart-rs232-usb-spi-i2c-ttl-etc-what-are-all-of-these-and-how-do-th) | - |
 
 <!-- ## How to Use This Book -->
@@ -130,7 +130,7 @@
 <!-- vendors, and often even different between Microcontroller families from the same -->
 <!-- vendor. -->
 
-この本は、ほとんどの例で、STマイクロエレクトロニクスの[STM32F3DISCOVERY]開発ボードを使用します。このボードは、ARM Cortex-Mアーキテクチャをベースとしています。基本機能はこのアーキテクチャベースのCPUでは共通です。一方、周辺機器とマイクロコントローラ実装の詳細は、他のベンダーと異なります。同じSTマイクロエレクトロニクスのマイクロコントローラファミリでも、違いがあります。
+この本は、ほとんどの例で、STマイクロエレクトロニクスの[STM32F3DISCOVERY]開発ボードを使用します。このボードは、ARM Cortex-Mアーキテクチャをベースとしています。基本機能はこのアーキテクチャベースのCPUでは共通です。一方、ペリフェラルとマイクロコントローラ実装の詳細は、他のベンダーと異なります。同じSTマイクロエレクトロニクスのマイクロコントローラファミリでも、違いがあります。
 
 <!-- For this reason, we suggest purchasing the [STM32F3DISCOVERY] development board -->
 <!-- for the purpose of following the examples in this book. -->


### PR DESCRIPTION
気になったところを修正してみました。

主な修正点：
* クォート(')やダブルクォート(")は鉤括弧(「」)にしました (Ref: https://github.com/rust-lang-ja/the-rust-programming-language-ja/blob/master/CONTRIBUTING.md)
* peripheralはペリフェラルと訳すようにしました
    *[APS](https://www.aps-web.jp/academy/)などではペリフェラルとしていたため。ただ、組込みに馴染みのない人にはわかりづらいかもしれないので、議論の余地があると思ってます
* Embedonomiconの説明について修正。
    * 中身のドキュメントをみるとライブラリを使わない方法での組込みプログラミングについて紹介していたので、[nitty-gritty](https://ejje.weblio.jp/content/nitty-gritty)を「より深い詳細」と訳してみました
* 「割り込み」を「割込み」に
    * 個人的には「割り込み」のほうが馴染みがあります
